### PR TITLE
added register_name variable

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'andschwa-mumble'
-version '0.0.3'
+version '0.0.4'
 source 'git://github.com/andschwa/puppet-mumble.git'
 author 'Andrew Schwartzmeyer'
 license 'MIT License'

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ parameters:
 
     # The following parameters affect mumble-server.ini through a template
     # For more info, see http://mumble.sourceforge.net/Murmur.ini
+    $register_name      = 'Mumble Server',
     $password           = undef,    # General entrance password
     $port               = 64738,
     $host               = '',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class mumble(
 
   # The following parameters affect mumble-server.ini through a template
   # For more info, see http://mumble.sourceforge.net/Murmur.ini
+  $register_name      = 'Mumble Server',
   $password           = '',    # General entrance password
   $port               = 64738,
   $host               = '',

--- a/templates/mumble-server.erb
+++ b/templates/mumble-server.erb
@@ -143,7 +143,7 @@ logdays=<%= scope['mumble::log_days'] %>
 # addresses.
 # Only uncomment the 'registerName' parameter if you wish to give your "Root" channel a custom name.
 #
-#registerName=Mumble Server
+registerName="<%= scope['mumble::register_name'] %>"
 #registerPassword=secret
 #registerUrl=http://mumble.sourceforge.net/
 #registerHostname=


### PR DESCRIPTION
Added register_name variable in puppet class to write into template for
mumble.ini.  Register Name is used for root channel name and Bonjour
announcements

Version has been increased to 0.0.4 ready for a release.
