### PR TITLE
Fix license in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "source": "https://github.com/voxpupuli/puppet-mumble.git",
   "project_page": "https://github.com/voxpupuli/puppet-mumble",
   "issues_url": "https://github.com/voxpupuli/puppet-mumble/issues",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "tags": [
     "murmurd",
     "mumble",


### PR DESCRIPTION
This got accidentally flipped in
https://github.com/voxpupuli/puppet-mumble/commit/1a340dc9ac5583b27c2447e373f935860f5f77a3

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
