### PR TITLE
Fix for server_password management

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,10 +123,10 @@ class mumble(
 
   if $server_password != undef {
     exec { 'mumble_set_password':
-      command => "/usr/sbin/murmurd -supw ${server_password} &> /dev/null && /usr/bin/touch /etc/mumble-server-puppet",
-      creates => '/etc/mumble-server-puppet',
-      require => Service['mumble-server'],
-      returns => [0,1],
+      command  => "/usr/sbin/murmurd -supw ${shell_escape($server_password)} 2>&1 | /bin/grep 'Superuser password set on server' && /usr/bin/touch /etc/mumble-server-puppet", # lint:ignore:140chars
+      creates  => '/etc/mumble-server-puppet',
+      require  => Service['mumble-server'],
+      provider => 'shell',
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,10 @@
     {
       "name": "puppetlabs/apt",
       "version_requirement": ">= 2.1.0 < 8.0.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.13.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/mumble_spec.rb
+++ b/spec/acceptance/mumble_spec.rb
@@ -1,13 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'mumble class' do
-  context 'with minimal parameters' do
-    pp = %(
-      class { 'mumble' :
-        password => 'Fo0b@rr',
-      }
-    )
-
+  shared_examples_for 'a module working correctly' do
     it 'installs without error' do
       apply_manifest(pp, catch_failures: true)
     end
@@ -23,5 +17,29 @@ describe 'mumble class' do
     describe command('netstat -napt') do
       its(:stdout) { is_expected.to match %r{^tcp.*64738.*LISTEN.*murmurd} }
     end
+  end
+
+  context 'with minimal parameters' do
+    let(:pp) do
+      %(
+        class { 'mumble' :
+          password => 'Fo0b@rr',
+        }
+      )
+    end
+
+    it_behaves_like 'a module working correctly'
+  end
+
+  context 'with a server_password' do
+    let(:pp) do
+      %(
+        class { 'mumble' :
+          server_password => 'It is Secret: $(rm -r /)',
+        }
+      )
+    end
+
+    it_behaves_like 'a module working correctly'
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,6 +16,16 @@ describe 'mumble', type: 'class' do
         it { is_expected.to contain_service('mumble-server') }
         it { is_expected.to contain_user('mumble-server') }
       end
+
+      context 'with a server_password' do
+        let(:params) do
+          {
+            server_password: 'It is Secret: $(rm -r /)'
+          }
+        end
+
+        it { is_expected.to contain_exec('mumble_set_password').with(command: %r{-supw It\\ is\\ Secret:\\ \\\$\\\(rm\\ -r\\ /\\\) 2>&1 \|}) }
+      end
     end
   end
 end


### PR DESCRIPTION


#### Pull Request (PR) description
The fix provided by #53 is incomplete: using shell redirections and control operators need to switch to the 'shell' exec provider, which in turn allows command injections.  Moreover, as explained in #52, murmurd exists with an exit code of 1 on success…  but also on failure.

Attempt to improve the situation by switching to the shell provider, shell escaping the password thanks to stdlib's shell_escape function, and grep the stderr output of murmurd for a success message.

#### This Pull Request (PR) fixes the following issues
n/a
