### PR TITLE
Relax dependencies version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.1.0 < 9.0.0"
+      "version_requirement": ">= 2.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 9.0.0"
+      "version_requirement": ">= 4.13.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Allow puppetlabs-stdlib 9.x
- Allow puppetlabs-apt 9.x
